### PR TITLE
🐛 Fix build error when no authorized_controllee_keys file exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,5 @@ run:
 # Supress errors if user doesn't overwrite existing key
 	ssh-keygen -t ed25519 -N '' -f internal/client/keys/private_key || true
 # Avoid duplicate entries
+	touch bin/authorized_controllee_keys
 	@grep -q "$$(cat internal/client/keys/private_key.pub)" bin/authorized_controllee_keys || cat internal/client/keys/private_key.pub >> bin/authorized_controllee_keys


### PR DESCRIPTION
Avoids the following error when doign a fresh build: `grep: bin/authorized_controllee_keys: No such file or directory`