### PR TITLE
Change timeouts on webserver to 5 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,15 +228,15 @@ The SSH ecosystem allowsy out define and call subsystems with the `-s` flag. In 
 
 
 #### All
-`list`  Lists avaiable subsystem
-`sftp`: Runs the sftp handler to transfer files
+`list`  Lists avaiable subsystem  
+`sftp`: Runs the sftp handler to transfer files  
 
 #### Linux
-`setgid`:   Attempt to change group
-`setuid`:   Attempt to change user
+`setgid`:   Attempt to change group  
+`setuid`:   Attempt to change user  
 
 #### Windows
-`service`: Installs or removes the rssh binary as a windows service, requires administrative rights
+`service`: Installs or removes the rssh binary as a windows service, requires administrative rights  
 
 
 e.g

--- a/internal/server/webserver/webserver.go
+++ b/internal/server/webserver/webserver.go
@@ -33,8 +33,8 @@ func Start(webListener net.Listener, connectBackAddress, projRoot string, public
 	}
 
 	srv := &http.Server{
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 5 * time.Second,
+		ReadTimeout:  20 * time.Second,
+		WriteTimeout: 20 * time.Second,
 		Handler:      buildAndServe(projRoot, connectBackAddress, validPlatforms, validArchs),
 	}
 

--- a/internal/server/webserver/webserver.go
+++ b/internal/server/webserver/webserver.go
@@ -33,8 +33,8 @@ func Start(webListener net.Listener, connectBackAddress, projRoot string, public
 	}
 
 	srv := &http.Server{
-		ReadTimeout:  2 * time.Second,
-		WriteTimeout: 2 * time.Second,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
 		Handler:      buildAndServe(projRoot, connectBackAddress, validPlatforms, validArchs),
 	}
 


### PR DESCRIPTION
The short timeouts often result in Windows clients (especially when using Invoke-WebRequest to fetch the client) erroring out as shown below:
![image](https://user-images.githubusercontent.com/5190840/178106808-6e078ed4-5926-454e-b27e-6c0d28d1b90e.png)

Increasing the timeout to 5 seconds seems to fix the issue.