### PR TITLE
Add --datadir flag to replace other flags

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -44,13 +44,15 @@ func CreateOrLoadServerKeys(privateKeyPath string) (ssh.Signer, error) {
 	return private, nil
 }
 
-func Run(addr, privateKeyPath string, authorizedKeys string, connectBackAddress, configPath string, insecure, enabledWebserver bool, timeout int) {
-
+func Run(addr, dataDir, connectBackAddress string, insecure, enabledWebserver bool, timeout int) {
 	c := mux.MultiplexerConfig{
 		SSH:          true,
 		TcpKeepAlive: timeout,
 		HTTP:         enabledWebserver,
 	}
+
+	privateKeyPath := filepath.Join(dataDir, "id_ed25519")
+	configPath := filepath.Join(dataDir, "config.json")
 
 	log.Println("Version: ", internal.Version)
 	var err error
@@ -62,17 +64,12 @@ func Run(addr, privateKeyPath string, authorizedKeys string, connectBackAddress,
 
 	log.Printf("Listening on %s\n", addr)
 
-	s, err := filepath.Abs(privateKeyPath)
-	if err != nil {
-		log.Fatalf("Unable to make absolute path from private key path [%s]: %s", privateKeyPath, err)
-	}
-
 	private, err := CreateOrLoadServerKeys(privateKeyPath)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	log.Printf("Loading private key from: %s (%s)\n", privateKeyPath, s)
+	log.Printf("Loading private key from: %s\n", privateKeyPath)
 
 	log.Println("Server key fingerprint: ", internal.FingerprintSHA256Hex(private.PublicKey()))
 
@@ -80,12 +77,11 @@ func Run(addr, privateKeyPath string, authorizedKeys string, connectBackAddress,
 		if len(connectBackAddress) == 0 {
 			connectBackAddress = addr
 		}
-		go webserver.Start(multiplexer.ServerMultiplexer.HTTP(), connectBackAddress, "../", private.PublicKey())
+		go webserver.Start(multiplexer.ServerMultiplexer.HTTP(), connectBackAddress, "../", dataDir, private.PublicKey())
 
 	}
 
 	go webhooks.StartWebhooks(configPath)
 
-	StartSSHServer(multiplexer.ServerMultiplexer.SSH(), private, insecure, authorizedKeys, timeout)
-
+	StartSSHServer(multiplexer.ServerMultiplexer.SSH(), private, insecure, dataDir, timeout)
 }

--- a/internal/server/webserver/buildmanager.go
+++ b/internal/server/webserver/buildmanager.go
@@ -250,7 +250,6 @@ func writeCache() {
 }
 
 func startBuildManager(cPath string) error {
-
 	c.Lock()
 	defer c.Unlock()
 

--- a/internal/server/webserver/webserver.go
+++ b/internal/server/webserver/webserver.go
@@ -22,12 +22,12 @@ var (
 	webserverOn        bool
 )
 
-func Start(webListener net.Listener, connectBackAddress, projRoot string, publicKey ssh.PublicKey) {
+func Start(webListener net.Listener, connectBackAddress, projRoot, dataDir string, publicKey ssh.PublicKey) {
 	projectRoot = projRoot
 	DefaultConnectBack = connectBackAddress
 	defaultFingerPrint = internal.FingerprintSHA256Hex(publicKey)
 
-	err := startBuildManager("./cache")
+	err := startBuildManager(filepath.Join(dataDir, "cache"))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This PR says bye-bye to `--config` `--key` and `--authorizedkeys`, instead replacing it with `--datadir`. This specifies a directory that contains:

- `authorized_keys`
- `authorized_controllee_keys`
- `config.json`
- `id_ed25519`
- `cache`
- Any files rssh needs in the future

This makes room for the magic new feature I'll PR in the next hour :)