### PR TITLE
Docker Support!

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.19-bullseye
+
+WORKDIR /app
+
+RUN apt update -y
+RUN apt upgrade -y
+RUN apt install -y upx-ucl gcc-mingw-w64
+
+COPY go.mod go.sum .
+RUN go mod download -x
+
+COPY . .
+RUN make server
+
+EXPOSE 2222
+
+RUN chmod +x /app/docker-entrypoint.sh
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+if [ ! -d "/data" ]; then
+    echo "Please mount /data"
+    exit 1
+fi
+
+if [ -z "$EXTERNAL_ADDRESS" ]; then
+    echo "Please specify EXTERNAL_ADDRESS"
+    exit 1
+fi
+
+touch /data/authorized_keys /data/authorized_controllee_keys
+
+# Allow user to seed the authorized_keys file
+if [ ! -z "$SEED_AUTHORIZED_KEYS" ]; then
+    if [ -s /data/authorized_keys ]; then
+        echo "authorized_keys is not empty, ignoring SEED_AUTHORIZED_KEYS\n"
+    else
+        echo "Seeding authorized_keys...\n"
+        echo $SEED_AUTHORIZED_KEYS > /data/authorized_keys
+    fi
+fi
+
+cd /app/bin
+./server --datadir /data --webserver --external_address $EXTERNAL_ADDRESS :2222


### PR DESCRIPTION
**This PR adds support for Docker!**

To test:

```
# Build
docker build -t reverse_ssh .

# Create a directory to store data in. You could use a docker volume instead.
mkdir ./data

# Run
docker run -p4321:2222 -e EXTERNAL_ADDRESS=example.com:4321 -e SEED_AUTHORIZED_KEYS="$(cat ~/.ssh/id_ed25519.pub)" -v ./data:/data reverse_ssh
```

The `SEED_AUTHORIZED_KEYS` env variable is not required. If not supplied, you'll need to manually add your key in `data/authorized_keys`. It is also a one-time operation -- if `authorized_keys` exists already and has contents, `SEED_AUTHORIZED_KEYS` will be ignored.

This is intended to be used with `link` for client compilation. No clients are compiled on build or run. DLLs and UPX are also supported out of the box!

**Future stuff:**

Once this eventually gets merged to main, CI/CD should be set up to push to dockerhub. Then, we can include a one-liner in the readme.