### PR TITLE
Fixed HTTP proxy support

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -39,7 +39,7 @@ func Connect(addr, proxy string, timeout time.Duration) (conn net.Conn, err erro
 	if len(proxy) != 0 {
 		log.Println("Setting HTTP proxy address as: ", proxy)
 
-		proxyCon, err := net.DialTimeout("tcp", addr, timeout)
+		proxyCon, err := net.DialTimeout("tcp", proxy, timeout)
 		if err != nil {
 			return conn, err
 		}


### PR DESCRIPTION
I think in fc1e977af4ebd072387bae7a0922262aba143735 the proxy support was accidentally corrupted. This fixes HTTP proxy support.

I submitted this PR against the unstable branch, hope this is correct.