### PR TITLE
adding option for lzma compression

### DIFF
--- a/internal/server/commands/link.go
+++ b/internal/server/commands/link.go
@@ -44,6 +44,7 @@ func (l *link) ValidArgs() map[string]string {
 		"fingerprint":       "Set RSSH server fingerprint will default to server public key",
 		"garble":            "Use garble to obfuscate the binary (requires garble to be installed)",
 		"upx":               "Use upx to compress the final binary (requires upx to be installed)",
+		"lzma":              "Use lzma compression for smaller binary at the cost of overhead at execution (requires upx flag to be set)",
 		"no-lib-c":          "Compile client without glibc",
 		"sni":               "When TLS is in use, set a custom SNI for the client to connect with",
 		"working-directory": "Set download/working directory for automatic script (i.e doing curl https://<url>.sh)",
@@ -117,6 +118,7 @@ func (l *link) Run(user *users.User, tty io.ReadWriter, line terminal.ParsedLine
 	buildConfig := webserver.BuildConfig{
 		SharedLibrary: line.IsSet("shared-object"),
 		UPX:           line.IsSet("upx"),
+		Lzma:          line.IsSet("lzma"),
 		Garble:        line.IsSet("garble"),
 		DisableLibC:   line.IsSet("no-lib-c"),
 

--- a/internal/server/webserver/buildmanager.go
+++ b/internal/server/webserver/buildmanager.go
@@ -215,16 +215,15 @@ func Build(config BuildConfig) (string, error) {
 	}
 
 	if config.UPX {
+		upxArgs := []string{"-qq", "-f", f.FilePath}
+
 		if config.Lzma {
-			output, err := exec.Command("upx", "--lzma", "-qq", "-f", f.FilePath).CombinedOutput()
-			if err != nil {
-				return "", errors.New("unable to run upx: " + err.Error() + ": " + string(output))
-			}
-		} else {
-			output, err := exec.Command("upx", "-qq", "-f", f.FilePath).CombinedOutput()
-			if err != nil {
-				return "", errors.New("unable to run upx: " + err.Error() + ": " + string(output))
-			}
+			upxArgs = append([]string{"--lzma"}, upxArgs...)
+		}
+
+		output, err := exec.Command("upx", upxArgs...).CombinedOutput()
+		if err != nil {
+			return "", errors.New("unable to run upx: " + err.Error() + ": " + string(output))
 		}
 	}
 

--- a/internal/server/webserver/buildmanager.go
+++ b/internal/server/webserver/buildmanager.go
@@ -38,6 +38,7 @@ type BuildConfig struct {
 
 	SharedLibrary bool
 	UPX           bool
+	Lzma          bool
 	Garble        bool
 	DisableLibC   bool
 	RawDownload   bool
@@ -209,10 +210,21 @@ func Build(config BuildConfig) (string, error) {
 
 	f.UrlPath = config.Name
 
+	if config.Lzma && !config.UPX {
+		return "", errors.New("Cannot use --lzma without --upx")
+	}
+
 	if config.UPX {
-		output, err := exec.Command("upx", "-qq", "-f", f.FilePath).CombinedOutput()
-		if err != nil {
-			return "", errors.New("unable to run upx: " + err.Error() + ": " + string(output))
+		if config.Lzma {
+			output, err := exec.Command("upx", "--lzma", "-qq", "-f", f.FilePath).CombinedOutput()
+			if err != nil {
+				return "", errors.New("unable to run upx: " + err.Error() + ": " + string(output))
+			}
+		} else {
+			output, err := exec.Command("upx", "-qq", "-f", f.FilePath).CombinedOutput()
+			if err != nil {
+				return "", errors.New("unable to run upx: " + err.Error() + ": " + string(output))
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds option to further compress the client with lzma.

examples of final client size:

| File                 | GOOS    | Size     |
| -------------------- | ------- | -------- |
| lzma                 | linux   | 2.65 MB  |
| lzma_win.exe         | windows | 3.43 MB  |
| uncompressed         | linux   | 8.94 MB  |
| uncompressed_win.exe | windows | 16.12 MB |
| upx                  | linux   | 3.49 MB  |
| upx_win.exe          | windows | 5.65 MB  |

