### PR TITLE
fix error when user in another domain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.23.1
 
 require (
 	github.com/ActiveState/termtest/conpty v0.5.0
-	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358
 	github.com/creack/pty v1.1.24
 	github.com/fatih/color v1.18.0
 	github.com/glebarez/sqlite v1.11.0
@@ -20,6 +19,8 @@ require (
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/bodgit/ntlmssp v0.0.0-20240506230425-31973bb52d9b // indirect
+	github.com/bodgit/windows v1.0.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/glebarez/go-sqlite v1.22.0 // indirect
 	github.com/google/btree v1.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,10 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg6
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/armon/go-proxyproto v0.0.0-20210323213023-7e956b284f0a/go.mod h1:QmP9hvJ91BbJmGVGSbutW19IC0Q9phDCLGaomwTJbgU=
+github.com/bodgit/ntlmssp v0.0.0-20240506230425-31973bb52d9b h1:baFN6AnR0SeC194X2D292IUZcHDs4JjStpqtE70fjXE=
+github.com/bodgit/ntlmssp v0.0.0-20240506230425-31973bb52d9b/go.mod h1:Ram6ngyPDmP+0t6+4T2rymv0w0BS9N8Ch5vvUJccw5o=
+github.com/bodgit/windows v1.0.1 h1:tF7K6KOluPYygXa3Z2594zxlkbKPAOvqr97etrGNIz4=
+github.com/bodgit/windows v1.0.1/go.mod h1:a6JLwrB4KrTR5hBpp8FI9/9W9jJfeQ2h4XDXU74ZCdM=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -144,7 +144,7 @@ func Connect(addr, proxy string, timeout time.Duration, winauth bool) (conn net.
 				if bytes.Contains(bytes.ToLower(responseStatus), []byte("proxy-authenticate: ntlm")) {
 					if ntlmProxyCreds != "" {
 						// Start NTLM negotiation
-						ntlmHeader, err := getNTLMAuthHeader(proxy, nil)
+						ntlmHeader, err := getNTLMAuthHeader(nil)
 						if err != nil {
 							return nil, fmt.Errorf("NTLM negotiation failed: %v", err)
 						}
@@ -189,7 +189,7 @@ func Connect(addr, proxy string, timeout time.Duration, winauth bool) (conn net.
 						}
 
 						// Generate Type 3 message
-						ntlmHeader, err = getNTLMAuthHeader(proxy, challenge)
+						ntlmHeader, err = getNTLMAuthHeader(challenge)
 						if err != nil {
 							return nil, fmt.Errorf("NTLM authentication failed: %v", err)
 						}


### PR DESCRIPTION
Hi!
In my case proxy server in domain_A, and user in domain_B. In the current logic, the domain name for generating Challenge Response is taken from the Targetinfo section in the NTLMSSP_Challenge message. But in this case it will be wrong when user in domain_B. 

I fixed this behavor by using another ntlmssp library for generate ntlm-messages.

Now the domain name is taken from the arguments that the user conveyed.