### PR TITLE
change watch command behavior to only exit on SIGINT - Ctrl-C

### DIFF
--- a/internal/server/commands/watch.go
+++ b/internal/server/commands/watch.go
@@ -139,12 +139,18 @@ func (w *watch) Run(user *users.User, tty io.ReadWriter, line terminal.ParsedLin
 	}
 
 	go func() {
-
 		b := make([]byte, 1)
-		tty.Read(b)
-
+		for {
+			_, err := tty.Read(b)
+			if err != nil {
+				break
+			}
+			if b[0] == 3 { // Ctrl-C
+				break
+			}
+			// Ignore all other keys
+		}
 		observers.ConnectionState.Deregister(observerId)
-
 		close(messages)
 	}()
 


### PR DESCRIPTION
The 'watch' command currently exits on any key press.  This change modifies the behavior to only exit on a SIGINT