### PR TITLE
Fixing a small regression with ssh tun devices and icmp

### DIFF
--- a/internal/client/handlers/tun.go
+++ b/internal/client/handlers/tun.go
@@ -201,7 +201,7 @@ func Tun(newChannel ssh.NewChannel, l logger.Logger) {
 		return
 	}
 
-	err = icmpResponder(ns)
+	err = icmpResponder(ns, NICID)
 	if err != nil {
 		l.Error("Unable to create icmp responder: %v", err)
 		return
@@ -617,7 +617,7 @@ func (*SSHEndpoint) WriteRawPacket(*stack.PacketBuffer) tcpip.Error {
 	return &tcpip.ErrNotSupported{}
 }
 
-func icmpResponder(s *stack.Stack) error {
+func icmpResponder(s *stack.Stack, nicID tcpip.NICID) error {
 
 	var wq waiter.Queue
 	rawProto, rawerr := raw.NewEndpoint(s, ipv4.ProtocolNumber, icmp.ProtocolNumber4, &wq)
@@ -637,6 +637,7 @@ func icmpResponder(s *stack.Stack) error {
 				// Wait for data to become available.
 
 				for range ch {
+					buff.Reset()
 
 					_, err := rawProto.Read(&buff, tcpip.ReadOptions{})
 
@@ -663,9 +664,14 @@ func icmpResponder(s *stack.Stack) error {
 					packetbuff.TransportProtocolNumber = icmp.ProtocolNumber4
 					packetbuff.NetworkHeader().Consume(hlen)
 
+					// Consume the transport header so ProcessICMP can read it via TransportHeader().Slice()
+					if !parse.ICMPv4(packetbuff) {
+						continue
+					}
+
 					go func() {
 						if TryResolve(iph.DestinationAddress().String()) {
-							ProcessICMP(s, packetbuff)
+							ProcessICMP(s, packetbuff, nicID)
 						}
 					}()
 				}
@@ -678,7 +684,7 @@ func icmpResponder(s *stack.Stack) error {
 
 // ProcessICMP send back a ICMP echo reply from after receiving a echo request.
 // This code come mostly from pkg/tcpip/network/ipv4/icmp.go
-func ProcessICMP(nstack *stack.Stack, pkt *stack.PacketBuffer) {
+func ProcessICMP(nstack *stack.Stack, pkt *stack.PacketBuffer, nicID tcpip.NICID) {
 	// (gvisor) pkg/tcpip/network/ipv4/icmp.go:174 - handleICMP
 	defer pkt.DecRef()
 
@@ -717,7 +723,7 @@ func ProcessICMP(nstack *stack.Stack, pkt *stack.PacketBuffer) {
 			localAddr = tcpip.Address{}
 		}
 
-		r, err := nstack.FindRoute(1, localAddr, ipHdr.SourceAddress(), ipv4.ProtocolNumber, false /* multicastLoop */)
+		r, err := nstack.FindRoute(nicID, localAddr, ipHdr.SourceAddress(), ipv4.ProtocolNumber, false /* multicastLoop */)
 		if err != nil {
 			// If we cannot find a route to the destination, silently drop the packet.
 			return
@@ -749,15 +755,6 @@ func ProcessICMP(nstack *stack.Stack, pkt *stack.PacketBuffer) {
 			Payload:            replyBuf,
 		})
 		defer replyPkt.DecRef()
-
-		// Populate the network/transport headers in the packet buffer so the
-		// ICMP packet goes through IPTables.
-		if ok := parse.IPv4(replyPkt); !ok {
-			panic("expected to parse IPv4 header we just created")
-		}
-		if ok := parse.ICMPv4(replyPkt); !ok {
-			panic("expected to parse ICMPv4 header we just created")
-		}
 
 		replyPkt.TransportProtocolNumber = header.ICMPv4ProtocolNumber
 		if err := r.WriteHeaderIncludedPacket(replyPkt); err != nil {


### PR DESCRIPTION
Fixing small regression from: [36065f5](https://github.com/NHAS/reverse_ssh/commit/36065f5).  nicid was changed from a hardcoded const to a randomly generated value, but never updated icmpResponder or ProcessICMP.

ICMP traffic with ssh tun devices silently broke as it was looking up routes on a NIC that no longer existed.  This passes the actual nicid through to icmpResponder and ProcessICMP so FindRoute looks up the right NIC. 

Also fixes a missing buff.Reset() and parses the ICMP transport header before processing.   