### PR TITLE
fix(mux): avoid blocking after buffered prefix

### DIFF
--- a/pkg/mux/bufferedConn.go
+++ b/pkg/mux/bufferedConn.go
@@ -13,18 +13,11 @@ type bufferedConn struct {
 func (bc *bufferedConn) Read(b []byte) (n int, err error) {
 	if len(bc.prefix) > 0 {
 		n = copy(b, bc.prefix)
-
 		bc.prefix = bc.prefix[n:]
 
-		var err error
-		if len(b)-n > 0 {
-			// If we havent exhausted the size of b, read some more
-			var actualRead int
-			actualRead, err = bc.conn.Read(b[n:])
-			n += actualRead
-		}
-
-		return n, err
+		// A net.Conn Read may return fewer bytes than len(b). Do not try to
+		// fill the rest of b here; that can block after protocol sniffing.
+		return n, nil
 	}
 
 	return bc.conn.Read(b)

--- a/pkg/mux/bufferedConn_test.go
+++ b/pkg/mux/bufferedConn_test.go
@@ -1,0 +1,55 @@
+package mux
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestBufferedConnReadUsesPrefixWithoutBlocking(t *testing.T) {
+	request := []byte("GET /main.sh HTTP/1.0\r\nHost: example\r\n\r\n")
+	blocking := &blockingConn{readStarted: make(chan struct{})}
+	bc := &bufferedConn{prefix: append([]byte(nil), request...), conn: blocking}
+
+	buf := make([]byte, 4096)
+	type readResult struct {
+		n   int
+		err error
+	}
+	done := make(chan readResult, 1)
+	go func() {
+		n, err := bc.Read(buf)
+		done <- readResult{n: n, err: err}
+	}()
+
+	select {
+	case result := <-done:
+		if result.err != nil {
+			t.Fatalf("read failed: %v", result.err)
+		}
+		if result.n != len(request) {
+			t.Fatalf("read %d bytes, want %d", result.n, len(request))
+		}
+	case <-blocking.readStarted:
+		t.Fatal("bufferedConn should not read from underlying conn while prefix has data")
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("bufferedConn.Read blocked waiting for underlying conn")
+	}
+}
+
+type blockingConn struct {
+	readStarted chan struct{}
+}
+
+func (c *blockingConn) Read([]byte) (int, error) {
+	close(c.readStarted)
+	select {}
+}
+
+func (c *blockingConn) Write([]byte) (int, error)        { return 0, nil }
+func (c *blockingConn) Close() error                     { return nil }
+func (c *blockingConn) LocalAddr() net.Addr              { return nil }
+func (c *blockingConn) RemoteAddr() net.Addr             { return nil }
+func (c *blockingConn) SetDeadline(time.Time) error      { return nil }
+func (c *blockingConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *blockingConn) SetWriteDeadline(time.Time) error { return nil }


### PR DESCRIPTION
## Summary

- stop `bufferedConn.Read` from doing an extra underlying `Read` after returning sniffed prefix bytes
- document why the early return is intentional
- add a regression test that fails if prefix reads block on the underlying connection

## Why

`determineProtocol` reads the initial protocol bytes and wraps the connection with `bufferedConn` so the selected handler can consume those bytes again. A `net.Conn.Read` is allowed to return fewer bytes than the caller's buffer size. The old implementation tried to fill the rest of the caller's buffer from the underlying connection after copying the prefix. For HTTP download requests, there may be no more immediate bytes, so this extra read can block before the HTTP server sees the buffered request bytes.

This is not removing validation. It removes the eager second read and keeps normal reads delegated to the underlying connection once the prefix is drained.

## Tests

- `go test ./pkg/mux`
- `go test -race ./pkg/mux`
- `go test ./...` fails on current `upstream/main` outside this diff: existing non-constant `fmt.Errorf` vet failures in `internal/server/...` and quote-handling failures in `internal/terminal/utils_test.go`.