### PR TITLE
Add map command and pivot topology tracking

### DIFF
--- a/internal/server/commands/init.go
+++ b/internal/server/commands/init.go
@@ -26,6 +26,7 @@ var allCommands = map[string]terminal.Command{
 	"autocomplete": &shellAutocomplete{},
 	"log":          &logCommand{},
 	"clear":        &clear{},
+	"map":          &mapCommand{},
 }
 
 func CreateCommands(session string, user *users.User, log logger.Logger, datadir string) map[string]terminal.Command {
@@ -48,6 +49,7 @@ func CreateCommands(session string, user *users.User, log logger.Logger, datadir
 		"autocomplete": &shellAutocomplete{},
 		"log":          Log(log),
 		"clear":        &clear{},
+		"map":          &mapCommand{},
 	}
 
 	return o

--- a/internal/server/commands/map.go
+++ b/internal/server/commands/map.go
@@ -1,0 +1,149 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/NHAS/reverse_ssh/internal/server/users"
+	"github.com/NHAS/reverse_ssh/internal/terminal"
+	"github.com/fatih/color"
+	"golang.org/x/crypto/ssh"
+)
+
+type mapCommand struct{}
+
+func (m *mapCommand) ValidArgs() map[string]string {
+	return map[string]string{
+		"h": "Print help",
+	}
+}
+
+type mapNode struct {
+	id       string
+	conn     *ssh.ServerConn
+	children []string
+}
+
+func (m *mapCommand) Run(user *users.User, tty io.ReadWriter, line terminal.ParsedLine) error {
+	allClients, err := user.SearchClients("")
+	if err != nil {
+		return err
+	}
+
+	if len(allClients) == 0 {
+		return fmt.Errorf("No RSSH clients connected")
+	}
+
+	// Build node map and collect parent relationships.
+	nodes := make(map[string]*mapNode, len(allClients))
+	for id, conn := range allClients {
+		nodes[id] = &mapNode{id: id, conn: conn}
+	}
+
+	// childOf maps child-id -> parent-id (only when parent is itself connected).
+	childOf := make(map[string]string)
+	for id, conn := range allClients {
+		parent := conn.Permissions.Extensions["pivot-parent"]
+		if parent == "" {
+			continue
+		}
+		if _, parentConnected := nodes[parent]; parentConnected {
+			childOf[id] = parent
+			nodes[parent].children = append(nodes[parent].children, id)
+		}
+	}
+
+	// Sort children lists for stable output.
+	for _, n := range nodes {
+		sort.Strings(n.children)
+	}
+
+	// Find roots: clients with no connected parent (direct or orphaned pivot).
+	roots := []string{}
+	for id := range nodes {
+		if _, hasParent := childOf[id]; !hasParent {
+			roots = append(roots, id)
+		}
+	}
+	sort.Strings(roots)
+
+	fmt.Fprintln(tty, color.HiWhiteString("RSSH"))
+
+	for i, rootID := range roots {
+		isLastRoot := i == len(roots)-1
+		printNode(tty, nodes, rootID, "", isLastRoot)
+	}
+
+	return nil
+}
+
+func printNode(tty io.ReadWriter, nodes map[string]*mapNode, id, prefix string, isLast bool) {
+	n := nodes[id]
+
+	branch := "├── "
+	childPrefix := prefix + "│   "
+	if isLast {
+		branch = "└── "
+		childPrefix = prefix + "    "
+	}
+
+	label := formatLabel(n.conn, id)
+	fmt.Fprintf(tty, "%s%s%s\n", prefix, branch, label)
+
+	for i, childID := range n.children {
+		isLastChild := i == len(n.children)-1
+		printNode(tty, nodes, childID, childPrefix, isLastChild)
+	}
+}
+
+func formatLabel(conn *ssh.ServerConn, id string) string {
+	keyID := conn.Permissions.Extensions["pubkey-fp"]
+	if conn.Permissions.Extensions["comment"] != "" {
+		keyID = conn.Permissions.Extensions["comment"]
+	}
+
+	hostname := users.NormaliseHostname(conn.User())
+	addr := conn.RemoteAddr().String()
+	version := string(conn.ClientVersion())
+
+	// Trim SSH version prefix for brevity ("SSH-_guess-windows_amd64" -> "windows_amd64")
+	version = strings.TrimPrefix(version, "SSH-_guess-")
+	version = strings.TrimPrefix(version, "SSH-2.0-")
+
+	pivot := ""
+	if conn.Permissions.Extensions["pivot-parent"] != "" {
+		pivot = color.YellowString(" [pivoted]")
+	}
+
+	shortKeyID := keyID
+	if len(keyID) > 4 {
+		shortKeyID = keyID[:4]
+	}
+
+	return fmt.Sprintf("%s %s %s (%s) [%s]%s",
+		color.YellowString(id),
+		color.CyanString(shortKeyID),
+		color.BlueString(hostname),
+		addr,
+		version,
+		pivot,
+	)
+}
+
+func (m *mapCommand) Expect(line terminal.ParsedLine) []string {
+	return nil
+}
+
+func (m *mapCommand) Help(explain bool) string {
+	const description = "Display a topology map of connected clients and their pivot chains"
+	if explain {
+		return description
+	}
+
+	return terminal.MakeHelpText(m.ValidArgs(),
+		"map",
+		description,
+	)
+}

--- a/internal/server/handlers/forwardserverport.go
+++ b/internal/server/handlers/forwardserverport.go
@@ -39,6 +39,16 @@ type chanConn struct {
 	remoteAddr chanAddress
 }
 
+// pivotConn wraps a net.Conn and records which client ID pivoted it.
+type pivotConn struct {
+	net.Conn
+	parentID string
+}
+
+func (p *pivotConn) PivotParent() string {
+	return p.parentID
+}
+
 func (c *chanConn) Read(b []byte) (n int, err error) {
 	return c.channel.Read(b)
 }
@@ -122,7 +132,7 @@ func ServerPortForward(clientId string) func(_ string, _ *users.User, newChannel
 		currentRemoteForwards[clientId] = net.JoinHostPort(drtMsg.Raddr, fmt.Sprintf("%d", drtMsg.Rport))
 		currentRemoteForwardsLck.Unlock()
 
-		multiplexer.ServerMultiplexer.QueueConn(channelToConn(connection, drtMsg))
+		multiplexer.ServerMultiplexer.QueueConn(&pivotConn{Conn: channelToConn(connection, drtMsg), parentID: clientId})
 
 	}
 }

--- a/internal/server/sshd.go
+++ b/internal/server/sshd.go
@@ -18,6 +18,7 @@ import (
 	"github.com/NHAS/reverse_ssh/internal/server/observers"
 	"github.com/NHAS/reverse_ssh/internal/server/users"
 	"github.com/NHAS/reverse_ssh/pkg/logger"
+	"github.com/NHAS/reverse_ssh/pkg/mux"
 	"github.com/fatih/color"
 	"golang.org/x/crypto/ssh"
 )
@@ -405,6 +406,9 @@ func getIP(ip string) net.IP {
 
 func acceptConn(c net.Conn, config *ssh.ServerConfig, timeout int, dataDir string) {
 
+	// Capture pivot parent before any wrapping obscures the annotation.
+	pivotParent := mux.GetPivotParent(c)
+
 	//Initially set the timeout high, so people who type in their ssh key password can actually use rssh
 	realConn := &internal.TimeoutConn{Conn: c, Timeout: time.Duration(timeout) * time.Minute}
 
@@ -413,6 +417,11 @@ func acceptConn(c net.Conn, config *ssh.ServerConfig, timeout int, dataDir strin
 	if err != nil {
 		log.Printf("Failed to handshake (%s)", err.Error())
 		return
+	}
+
+	// Record pivot parent (if any) so commands like 'map' can reconstruct topology.
+	if pivotParent != "" && sshConn.Permissions != nil {
+		sshConn.Permissions.Extensions["pivot-parent"] = pivotParent
 	}
 
 	clientLog := logger.NewLog(sshConn.RemoteAddr().String())

--- a/pkg/mux/bufferedConn.go
+++ b/pkg/mux/bufferedConn.go
@@ -5,9 +5,47 @@ import (
 	"time"
 )
 
+// PivotParenter is implemented by conns that were tunnelled through another client.
+type PivotParenter interface {
+	PivotParent() string
+}
+
+// GetPivotParent walks wrapper chains to find a pivot parent ID, if any.
+func GetPivotParent(c net.Conn) string {
+	type unwrapper interface {
+		Unwrap() net.Conn
+	}
+	for c != nil {
+		if p, ok := c.(PivotParenter); ok {
+			return p.PivotParent()
+		}
+		u, ok := c.(unwrapper)
+		if !ok {
+			break
+		}
+		c = u.Unwrap()
+	}
+	return ""
+}
+
+// tlsConnWrapper wraps a *tls.Conn and exposes Unwrap so GetPivotParent
+// can reach through TLS to find a pivot parent.
+type tlsConnWrapper struct {
+	net.Conn
+	inner net.Conn
+}
+
+func (t *tlsConnWrapper) Unwrap() net.Conn {
+	return t.inner
+}
+
 type bufferedConn struct {
 	prefix []byte
 	conn   net.Conn
+}
+
+func (bc *bufferedConn) Unwrap() net.Conn {
+	return bc.conn
 }
 
 func (bc *bufferedConn) Read(b []byte) (n int, err error) {

--- a/pkg/mux/multiplexer.go
+++ b/pkg/mux/multiplexer.go
@@ -547,12 +547,15 @@ func (m *Multiplexer) unwrapTransports(conn net.Conn) (net.Conn, protocols.Type,
 		}
 
 		// this is TLS so replace the connection
-		c := tls.Server(conn, m.config.tlsConfig)
-		err := c.Handshake()
+		tlsConn := tls.Server(conn, m.config.tlsConfig)
+		err := tlsConn.Handshake()
 		if err != nil {
 			conn.Close()
 			return nil, protocols.Invalid, fmt.Errorf("multiplexing failed (tls handshake): err: %s", err)
 		}
+
+		// Wrap so that GetPivotParent can reach through TLS to the underlying conn.
+		c := &tlsConnWrapper{Conn: tlsConn, inner: conn}
 
 		// If we did unwrap tls, we now peek into the inner protocol to see whats there
 		conn, proto, err = m.determineProtocol(c)

--- a/pkg/mux/websocketwrapper.go
+++ b/pkg/mux/websocketwrapper.go
@@ -35,6 +35,10 @@ func (ww *websocketWrapper) Close() error {
 	return err
 }
 
+func (ww *websocketWrapper) Unwrap() net.Conn {
+	return ww.tcpConn
+}
+
 func (ww *websocketWrapper) LocalAddr() net.Addr {
 	return ww.tcpConn.LocalAddr()
 }


### PR DESCRIPTION
# Description

Adds a `map` command to visualize pivot topology, and propagates pivot-parent information through the mux, TLS, and port-forwarding layers so that pivoted connections can be tracked and displayed.

## Why?

Currently, there's no way to see how pivoted connections relate to each other when there are multiple hops. This adds visibility into the pivot chain so operators can understand the network topology at a glance

Here is how a double pivot through 2 agents would look with `map`:

<img width="3075" height="417" alt="image" src="https://github.com/user-attachments/assets/18bcb041-2756-4b2d-ba0a-75ade506ee55" />

This clearly shows the pivot-parent relationship and helps to visualize which agent was used as a pivot for which agent.
